### PR TITLE
fix metfile_search

### DIFF
--- a/solweig_gpu/utci_process.py
+++ b/solweig_gpu/utci_process.py
@@ -63,8 +63,8 @@ def load_raster_to_tensor(dem_path):
 def extract_key(filename, is_metfile=False):
 
     if is_metfile:
-        # look for metfile_X_Y_DATE
-        match = re.search(r'metfile_(\d+)_(\d+)_\d{4}-\d{2}-\d{2}', filename)
+        # look for metfile_X_Y
+        match = re.search(r'metfile_(\d+)_(\d+)', filename)
     else:
         # look for ..._X_Y.tif
         match = re.search(r'_(\d+)_(\d+)', filename)


### PR DESCRIPTION
I am currently testing this code with the provided sample data, using the .txt metfile.

By default, the model stopped [here](https://github.com/matthiasdemuzere/SOLWEIG-GPU/blob/1fe1463f6909886f093ba025f88c4727d8b04e69/solweig_gpu/solweig_gpu.py#L68), because `met_map` keys where empty, leading to empty `common_keys`. 

met_map keys are empty because no files could be found mathing the search string that looks for pattern X_Y_DATE. Just because _DATE is not part of the string.

This small PR fixes this, by removing the `_DATE` pattern.

In case the program requires to have the _DATE, then I assume this should be changed in ppr's [create_met_files](https://github.com/matthiasdemuzere/SOLWEIG-GPU/blob/1fe1463f6909886f093ba025f88c4727d8b04e69/solweig_gpu/preprocessor.py#L637)?