### PR TITLE
Type Error Fix for NumPy 2.4.0

### DIFF
--- a/solweig_gpu/sun_position.py
+++ b/solweig_gpu/sun_position.py
@@ -951,6 +951,9 @@ def Solweig_2015a_metdata_noload(inputdata, location, UTC):
 
     sunmax = dict()
 
+    def _scalar(value):
+        return np.asarray(value).item()
+
     for i, row in enumerate(met[:, 0]):
         if met[i, 1] == 221:
             test = 4
@@ -959,9 +962,9 @@ def Solweig_2015a_metdata_noload(inputdata, location, UTC):
         if (i == 0) or (np.mod(dectime[i], np.floor(dectime[i])) == 0):
             fifteen = 0.
             sunmaximum = -90.
-            sunmax['zenith'] = 90.
-            while sunmaximum <= 90. - sunmax['zenith']:
-                sunmaximum = 90. - sunmax['zenith']
+            sunmax_zenith = 90.
+            while sunmaximum <= 90. - sunmax_zenith:
+                sunmaximum = 90. - sunmax_zenith
                 fifteen = fifteen + 15. / 1440.
                 HM = datetime.timedelta(days=(60*10)/1440.0 + fifteen)
                 YMDHM = YMD + HM
@@ -971,7 +974,8 @@ def Solweig_2015a_metdata_noload(inputdata, location, UTC):
                 time['hour'] = YMDHM.hour
                 time['min'] = YMDHM.minute
                 sunmax = sun_position(time,location)
-        altmax[0, i] = sunmaximum
+                sunmax_zenith = _scalar(sunmax['zenith'])
+        altmax[0, i] = _scalar(sunmaximum)
 
         half = datetime.timedelta(days=halftimestepdec)
         H = datetime.timedelta(hours=met[i, 2])
@@ -983,11 +987,13 @@ def Solweig_2015a_metdata_noload(inputdata, location, UTC):
         time['hour'] = YMDHM.hour
         time['min'] = YMDHM.minute
         sun = sun_position(time, location)
-        if (sun['zenith'] > 89.0) & (sun['zenith'] <= 90.0):    
-            sun['zenith'] = 89.0
-        altitude[0, i] = 90. - sun['zenith']
-        zen[0, i] = sun['zenith'] * (np.pi/180.)
-        azimuth[0, i] = sun['azimuth']
+        sun_zenith = _scalar(sun['zenith'])
+        sun_azimuth = _scalar(sun['azimuth'])
+        if (sun_zenith > 89.0) & (sun_zenith <= 90.0):    
+            sun_zenith = 89.0
+        altitude[0, i] = 90. - sun_zenith
+        zen[0, i] = sun_zenith * (np.pi/180.)
+        azimuth[0, i] = sun_azimuth
 
         # day of year and check for leap year
         if calendar.isleap(time['year']):

--- a/solweig_gpu/utci_process.py
+++ b/solweig_gpu/utci_process.py
@@ -311,10 +311,10 @@ def compute_utci(building_dsm_path, tree_path, dem_path, walls_path, aspect_path
         Tstart        = torch.from_numpy(Tstart_np).to(device).float()
         alb_grid      = torch.from_numpy(alb_np).to(device).float()
         emis_grid     = torch.from_numpy(emis_np).to(device).float()
-        TgK_wall      = torch.tensor(float(TgK_wall_np)     , device=device)
-        Tstart_wall   = torch.tensor(float(Tstart_wall_np)  , device=device)
+        TgK_wall      = torch.tensor(np.asarray(TgK_wall_np).item(), device=device)
+        Tstart_wall   = torch.tensor(np.asarray(Tstart_wall_np).item(), device=device)
         TmaxLST       = torch.from_numpy(TmaxLST_np ).to(device).float()
-        TmaxLST_wall  = torch.tensor(float(TmaxLST_wall_np) , device=device)
+        TmaxLST_wall  = torch.tensor(np.asarray(TmaxLST_wall_np).item(), device=device)
     else:
         TgK = Knight + 0.37
         Tstart = Knight - 3.41
@@ -566,5 +566,4 @@ def compute_utci(building_dsm_path, tree_path, dem_path, walls_path, aspect_path
     end_time = time.time()
     time_taken = end_time - start_time
     print(f"Time taken to execute tile {number}: {time_taken:.2f} seconds")
-
 


### PR DESCRIPTION
This PR resolves NumPy 2.4.0+ failures caused by implicit conversion of non-scalar arrays to scalars. These cases have emitted a DeprecationWarning since NumPy 1.25 but now raise an error in newer NumPy versions. (NumPy 2.4.0 is used when installed using `uv` with latest Python which leads to this error)

[sun_position() returned a rank-1 array of shape (1,)](https://github.com/nvnsudharsan/SOLWEIG-GPU/blob/522acb43fcaa8ef7b6d1afc058605df9f2983e46/solweig_gpu/sun_position.py#L973)  
in a code path that requires a scalar dtype value. Assigning a 1-D array into a scalar array element relies on implicit array-to-scalar coercion, which is deprecated and raises TypeError on NumPy 2.4+.

```python3
# Errors on newer NumPy; was a DeprecationWarning up to 2.3.x.
>>> import numpy as np
>>> a = np.array([0, 1, 2, 3])
>>> a[3] = np.array([42])
<stdin>:1: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
>>> a
array([ 0,  1,  2, 42])
```

[A similar deprecated conversion occurs in utci_process.py](https://github.com/nvnsudharsan/SOLWEIG-GPU/blob/522acb43fcaa8ef7b6d1afc058605df9f2983e46/solweig_gpu/utci_process.py#L314).  
Here, calling float() on a rank-1 array of shape (1,) triggers the same implicit conversion and raises TypeError on NumPy 2.4+.

```python3
>>> import numpy as np
>>> a = np.array([2])
>>> float(a)
<stdin>:1: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
2.0
```

(PR code was created using OpenAI Codex; description was revised using ChatGPT 5.2 Thinking.)