### PR TITLE
Fix PyTorch 2.6+ bool tensor and unbound variable errors

### DIFF
--- a/solweig_gpu/shadow.py
+++ b/solweig_gpu/shadow.py
@@ -102,8 +102,8 @@ def shadow(amaxvalue, a, vegdem, vegdem2, bush, azimuth, altitude, scale):
 
     f = a.clone()
     g = torch.zeros((sizex, sizey), device=device)
-    bushplant = bush > 1.
-    vegsh = torch.zeros((sizex, sizey), device=device) + bushplant.float()
+    bushplant = (bush > 1.).float()
+    vegsh = torch.zeros((sizex, sizey), device=device) + bushplant
 
     pibyfour = torch.pi / 4.
     threetimespibyfour = 3. * pibyfour
@@ -119,6 +119,10 @@ def shadow(amaxvalue, a, vegdem, vegdem2, bush, azimuth, altitude, scale):
     tanaltitudebyscale = torch.tan(altitude) / scale
 
     index = 1
+    fabovea = None
+    gabovea = None
+    vegsh2 = None
+
     while (amaxvalue >= dz and torch.abs(dx) < sizex and torch.abs(dy) < sizey):
         if (pibyfour <= azimuth < threetimespibyfour or fivetimespibyfour <= azimuth < seventimespibyfour):
             dy = signsinazimuth * index

--- a/solweig_gpu/solweig.py
+++ b/solweig_gpu/solweig.py
@@ -1082,10 +1082,10 @@ def shadowingfunction_wallheight_23(a, vegdem, vegdem2, azimuth, altitude, scale
     tempvegdem2 = torch.zeros((sizex, sizey), device=device)
     templastfabovea = torch.zeros((sizex, sizey), device=device)
     templastgabovea = torch.zeros((sizex, sizey), device=device)
-    bushplant = bush > 1
-    sh = torch.zeros((sizex, sizey), device=device) 
-    vbshvegsh = torch.zeros((sizex, sizey), device=device) 
-    vegsh = torch.zeros((sizex, sizey), device=device) + bushplant.float() 
+    bushplant = (bush > 1).float()
+    sh = torch.zeros((sizex, sizey), device=device)
+    vbshvegsh = torch.zeros((sizex, sizey), device=device)
+    vegsh = torch.zeros((sizex, sizey), device=device) + bushplant
     f = a 
     shvoveg = vegdem 
     wallbol = (walls > 0).float()
@@ -1105,6 +1105,11 @@ def shadowingfunction_wallheight_23(a, vegdem, vegdem2, azimuth, altitude, scale
 
     index = 0
     dzprev = torch.tensor(0.0, device=device)
+    fabovea = None
+    gabovea = None
+    lastfabovea = None
+    lastgabovea = None
+    vegsh2 = None
 
     while (amaxvalue >= dz) and (torch.abs(dx) < sizex) and (torch.abs(dy) < sizey):
         if ((pibyfour <= azimuth) and (azimuth < threetimespibyfour)) or ((fivetimespibyfour <= azimuth) and (azimuth < seventimespibyfour)):


### PR DESCRIPTION
Two bugs in shadow.py and solweig.py:

  1. bush > 1 returns a bool tensor. PyTorch 2.6+ disallows arithmetic (+, -) on bool tensors, raising
  RuntimeError. Fix: cast to float immediately with (bush > 1).float()
  
  2. fabovea, gabovea, vegsh2 (and lastfabovea, lastgabovea in solweig.py) are only assigned inside while
  loops. If the loop never executes, the del cleanup raises UnboundLocalError. Fix: initialize to None
  before the loop