### PR TITLE
Fix svfN accumulation, ensure_tensor typo, and bush indexing

### DIFF
--- a/solweig_gpu/shadow.py
+++ b/solweig_gpu/shadow.py
@@ -77,7 +77,7 @@ def shadow(amaxvalue, a, vegdem, vegdem2, bush, azimuth, altitude, scale):
     if azimuth == 0.0:
         azimuth = 1e-12
     azimuth = ensure_tensor(azimuth)
-    altitutde = ensure_tensor(altitude)
+    altitude = ensure_tensor(altitude)
     azimuth = azimuth * degrees #torch.tensor(azimuth * degrees, device=a.device)
     altitude = altitude * degrees #torch.tensor(altitude * degrees, device=a.device)
 
@@ -171,7 +171,7 @@ def shadow(amaxvalue, a, vegdem, vegdem2, bush, azimuth, altitude, scale):
 
         if bush.max() > 0. and torch.max(fabovea * bush) > 0.:
             tempbush.zero_()
-            tempbush[int(xp1)-1:int(xp2), int(yp1)-1:int(yp2)] = bush[int(xc1)-1:int(xc2), int(yc1)-1:int(yc2)] - dz
+            tempbush[int(xp1):int(xp2), int(yp1):int(yp2)] = bush[int(xc1):int(xc2), int(yc1):int(yc2)] - dz
             g = torch.max(g, tempbush)
             g *= bushplant
 
@@ -373,7 +373,7 @@ def svf_calculator(patch_option,amaxvalue, a, vegdem, vegdem2, bush, scale):
                     svfS = svfS + weight
                 if 180 <= azimuth < 360:
                     svfW = svfW + weight
-                if 270 <= azimuth < 90:
+                if azimuth >= 270 or azimuth < 90:
                     svfN = svfN + weight
 
                 weight = annulus_weight(k, aziinterval[i], device)
@@ -389,7 +389,7 @@ def svf_calculator(patch_option,amaxvalue, a, vegdem, vegdem2, bush, scale):
                 if 180 <= azimuth < 360:
                     svfWveg = svfWveg + weight * vegsh
                     svfWaveg = svfWaveg + weight * vbshvegsh
-                if 270 <= azimuth < 90:
+                if azimuth >= 270 or azimuth < 90:
                     svfNveg = svfNveg + weight * vegsh
                     svfNaveg = svfNaveg + weight * vbshvegsh
 

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -1,0 +1,60 @@
+"""
+Unit tests for shadow.py – covers the svfN accumulation fix
+and bush indexing consistency.
+"""
+
+import torch
+import pytest
+from solweig_gpu.shadow import svf_calculator
+
+
+def _build_small_scene(size=20):
+    """Create a minimal urban scene with one building for SVF testing."""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    dem = torch.zeros((size, size), device=device)
+    dsm = dem.clone()
+    dsm[8:12, 8:12] = 10.0  # 10 m building in the centre
+
+    tree_height = torch.zeros((size, size), device=device)
+    vegdsm = tree_height + dsm
+    vegdsm[vegdsm == dsm] = 0
+    vegdsm2 = tree_height * 0.25 + dsm
+    vegdsm2[vegdsm2 == dsm] = 0
+
+    bush = torch.zeros((size, size), device=device)
+    amaxvalue = dsm.max()
+    scale = 1.0  # 1 pixel = 1 m
+
+    return amaxvalue, dsm, vegdsm, vegdsm2, bush, scale
+
+
+def test_svfN_is_nonzero():
+    """svfN must be accumulated for north-facing azimuths (>=270 or <90).
+
+    Before the fix, the condition ``270 <= azimuth < 90`` was always False,
+    leaving svfN as all zeros.  After the fix it should contain positive
+    values comparable in magnitude to svfE / svfS / svfW.
+    """
+    amaxvalue, dsm, vegdsm, vegdsm2, bush, scale = _build_small_scene()
+
+    result = svf_calculator(2, amaxvalue, dsm, vegdsm, vegdsm2, bush, scale)
+    # Return order: svf, svfaveg, svfE, svfEaveg, svfEveg, svfN, svfNaveg,
+    #               svfNveg, svfS, svfSaveg, svfSveg, svfveg, svfW, svfWaveg,
+    #               svfWveg, vegshmat, vbshvegshmat, shmat, SVFtotal
+    svfE = result[2]
+    svfN = result[5]
+    svfS = result[8]
+    svfW = result[12]
+
+    # All directional SVFs should be non-zero where there is sky exposure
+    assert svfN.sum().item() > 0, "svfN is all zeros – north accumulation broken"
+    assert svfE.sum().item() > 0, "svfE is all zeros"
+    assert svfS.sum().item() > 0, "svfS is all zeros"
+    assert svfW.sum().item() > 0, "svfW is all zeros"
+
+    # svfN should be roughly the same order of magnitude as the other directions
+    ratio = svfN.sum().item() / svfE.sum().item()
+    assert 0.3 < ratio < 3.0, (
+        f"svfN/svfE ratio {ratio:.3f} is unreasonable – accumulation may still be wrong"
+    )


### PR DESCRIPTION
- Fix svfN (north-facing Sky View Factor) never being accumulated due to always-False Python chained
  comparison 270 <= azimuth < 90 — changed to azimuth >= 270 or azimuth < 90
- Fix misspelled variable "altitutde"
- Fix off-by-one bush shadow indexing (-1 on slice starts) to match the building/vegetation indexing (similar to lines 148-150)