### PR TITLE
Feat: allow trunk zone dsm as an option

### DIFF
--- a/solweig_gpu/preprocessor.py
+++ b/solweig_gpu/preprocessor.py
@@ -1210,7 +1210,7 @@ def ppr(base_path, building_dsm_filename, dem_filename, trees_filename,
          landcover_filename, windcoeff_filename,
          tile_size, overlap, selected_date_str, use_own_met,
          start_time=None, end_time=None, data_source_type=None, data_folder=None,
-         own_met_file=None, preprocess_dir=None, use_uhi=True):
+         own_met_file=None, preprocess_dir=None, use_uhi=True, trunkzone_filename=None):
     """
     Preprocessing routine to validate raster files, generate tiles, and prepare metfiles for SOLWEIG.
 
@@ -1218,7 +1218,7 @@ def ppr(base_path, building_dsm_filename, dem_filename, trees_filename,
         base_path (str): Base working directory containing input rasters.
         building_dsm_filename (str): Filename of building DSM raster.
         dem_filename (str): Filename of DEM raster.
-        trees_filename (str): Filename of trees raster.
+        trees_filename (str): Filename of trees canopy DSM raster.
         landcover_filename (str): Filename of landcover raster or None.
         windcoeff_filename (str): Filename of wind coefficient raster or None.
         tile_size (int): Tile size in pixels.
@@ -1232,6 +1232,8 @@ def ppr(base_path, building_dsm_filename, dem_filename, trees_filename,
         own_met_file (str): Path to user-provided met file (used if use_own_met is True).
         preprocess_dir (str): Directory for preprocessing outputs.
         use_uhi (bool): Whether to use UHI-aware ERA5 preprocessing.
+        trunkzone_filename (str): Filename of trunk-zone DSM raster (height in m agl)
+            or None. If None, the trunk zone is derived as 25% of the canopy height.
     """
     if preprocess_dir is None:
         preprocess_dir = os.path.join(base_path, "processed_inputs")
@@ -1243,12 +1245,16 @@ def ppr(base_path, building_dsm_filename, dem_filename, trees_filename,
 
     landcover_path = None
     windcoeff_path = None
+    trunkzone_path = None
 
     if landcover_filename is not None:
         landcover_path = os.path.join(base_path, landcover_filename)
 
     if windcoeff_filename is not None:
         windcoeff_path = os.path.join(base_path, windcoeff_filename)
+
+    if trunkzone_filename is not None:
+        trunkzone_path = os.path.join(base_path, trunkzone_filename)
 
     # Check that all rasters have matching dimensions, pixel size, and CRS.
     try:
@@ -1259,6 +1265,9 @@ def ppr(base_path, building_dsm_filename, dem_filename, trees_filename,
 
         if windcoeff_path is not None:
             raster_list.append(windcoeff_path)
+
+        if trunkzone_path is not None:
+            raster_list.append(trunkzone_path)
 
         check_rasters(raster_list)
 
@@ -1277,6 +1286,9 @@ def ppr(base_path, building_dsm_filename, dem_filename, trees_filename,
 
     if windcoeff_path is not None:
         rasters["WindCoeff"] = windcoeff_path
+
+    if trunkzone_path is not None:
+        rasters["TrunkZone"] = trunkzone_path
 
     for tile_type, raster in rasters.items():
         print(f"Creating tiles for {tile_type}...")

--- a/solweig_gpu/solweig_gpu.py
+++ b/solweig_gpu/solweig_gpu.py
@@ -35,6 +35,7 @@ def preprocess(
     own_met_file: Optional[str] = None,
     preprocess_dir: Optional[str] = None,
     use_uhi: bool = True,
+    trunkzone_filename: Optional[str] = None,
 ) -> str:
     """
     Run preprocessing only: validate rasters, create tiles, and prepare metfiles.
@@ -60,6 +61,9 @@ def preprocess(
         use_uhi: If True, use UHI-aware ERA5 processing and write UHI_CYCLE/uhii
             into generated metfiles when available. If False, use standard ERA5
             processing and write uhii = 0.0.
+        trunkzone_filename: Optional trunk-zone DSM raster (height in m agl, same
+            grid as the DSM). If None, the trunk zone is derived as 25% of the
+            canopy height.
 
     Returns:
         The path to the preprocessing directory (tiles and metfiles written there).
@@ -89,6 +93,7 @@ def preprocess(
         own_met_file,
         preprocess_dir=preprocess_dir,
         use_uhi=use_uhi,
+        trunkzone_filename=trunkzone_filename,
     )
     return preprocess_dir
 
@@ -308,6 +313,7 @@ def run_utci_tiles(
     input_met = os.path.join(preprocess_dir, "metfiles")
     building_dsm_dir = os.path.join(preprocess_dir, "Building_DSM")
     tree_dir = os.path.join(preprocess_dir, "Trees")
+    trunkzone_dir = os.path.join(preprocess_dir, "TrunkZone")
     dem_dir = os.path.join(preprocess_dir, "DEM")
     landcover_dir = os.path.join(preprocess_dir, "Landcover")
     windcoeff_dir = os.path.join(preprocess_dir, "WindCoeff")
@@ -316,6 +322,7 @@ def run_utci_tiles(
 
     building_dsm_map = map_files_by_key(building_dsm_dir, ".tif")
     tree_map = map_files_by_key(tree_dir, ".tif")
+    trunkzone_map = map_files_by_key(trunkzone_dir, ".tif") if os.path.isdir(trunkzone_dir) else {}
     dem_map = map_files_by_key(dem_dir, ".tif")
     landcover_map = map_files_by_key(landcover_dir, ".tif") if os.path.isdir(landcover_dir) else {}
     windcoeff_map = map_files_by_key(windcoeff_dir, ".tif") if os.path.isdir(windcoeff_dir) else {}
@@ -342,6 +349,7 @@ def run_utci_tiles(
     for key in sorted(common_keys, key=_numeric_key):
         building_dsm_path = building_dsm_map[key]
         tree_path = tree_map[key]
+        trunk_path = trunkzone_map.get(key) if trunkzone_map else None
         dem_path = dem_map[key]
         landcover_path = landcover_map.get(key) if landcover_map else None
         windcoeff_path = windcoeff_map.get(key) if windcoeff_map else None
@@ -366,6 +374,7 @@ def run_utci_tiles(
             output_folder,
             key,
             selected_date_str,
+            trunk_path=trunk_path,
             save_tmrt=save_tmrt,
             save_svf=save_svf,
             save_kup=save_kup,
@@ -388,6 +397,7 @@ def thermal_comfort(
     trees_filename='Trees.tif',
     landcover_filename: Optional[str] = None,
     windcoeff_filename: Optional[str] = None,
+    trunkzone_filename: Optional[str] = None,
     tile_size=3600,
     overlap=20,
     use_own_met=True,
@@ -416,9 +426,12 @@ def thermal_comfort(
         selected_date_str (str): Simulation date in format 'YYYY-MM-DD'
         building_dsm_filename (str): Building+terrain DSM path or filename.
         dem_filename (str): DEM path or filename.
-        trees_filename (str): Vegetation DSM path or filename.
+        trees_filename (str): Vegetation canopy DSM path or filename.
         landcover_filename (str, optional): Land cover raster path or filename.
         windcoeff_filename (str, optional): Wind coefficient raster path or filename.
+        trunkzone_filename (str, optional): Trunk-zone DSM raster path or filename
+            (height in m agl, same grid as the DSM). If None, the trunk zone is
+            derived as 25% of the canopy height.
         tile_size (int): Tile size in pixels.
         overlap (int): Overlap between tiles in pixels.
         use_own_met (bool): Use custom meteorological file.
@@ -450,6 +463,7 @@ def thermal_comfort(
         trees_filename=trees_filename,
         landcover_filename=landcover_filename,
         windcoeff_filename=windcoeff_filename,
+        trunkzone_filename=trunkzone_filename,
         tile_size=tile_size,
         overlap=overlap,
         use_own_met=use_own_met,

--- a/solweig_gpu/utci_process.py
+++ b/solweig_gpu/utci_process.py
@@ -271,7 +271,7 @@ def load_cached_svf_outputs(building_dsm_path: str, number: str):
         svfW, svfWaveg, svfWveg, vegshmat, vbshvegshmat, shmat, svftotal,)
 
 def compute_utci(building_dsm_path, tree_path, dem_path, walls_path, aspect_path, landcover_path, windcoeff_path, met_file,
-                output_path,number,selected_date_str,save_tmrt=False,save_svf=False, save_kup=False,save_kdown=False,save_lup=False,
+                output_path,number,selected_date_str,trunk_path=None,save_tmrt=False,save_svf=False, save_kup=False,save_kdown=False,save_lup=False,
                 save_ldown=False,save_shadow=False,save_wbgt=False,save_ta=False,save_wind=False):
     """
     Compute UTCI and related thermal comfort outputs for a single tile.
@@ -281,8 +281,10 @@ def compute_utci(building_dsm_path, tree_path, dem_path, walls_path, aspect_path
     
     Args:
         building_dsm_path (str): Path to Building DSM raster
-        tree_path (str): Path to tree/vegetation DSM raster
+        tree_path (str): Path to tree/vegetation canopy DSM raster (height in m agl)
         dem_path (str): Path to Digital Elevation Model raster
+        trunk_path (str): Path to trunk-zone DSM raster (height in m agl, same grid
+            as the DSM). If None, the trunk zone is derived as 25% of the canopy height.
         walls_path (str): Path to wall height raster
         aspect_path (str): Path to wall aspect raster  
         landcover_path (str): Path to land cover raster (can be None)
@@ -313,6 +315,11 @@ def compute_utci(building_dsm_path, tree_path, dem_path, walls_path, aspect_path
     a, dataset = load_raster_to_tensor(building_dsm_path)
     temp1, dataset2 = load_raster_to_tensor(tree_path)
     temp2, dataset3 = load_raster_to_tensor(dem_path)
+
+    trunk = None
+    if trunk_path is not None:
+        trunk, _ = load_raster_to_tensor(trunk_path)
+        trunk[trunk < 0.] = 0.
     walls, dataset4 = load_raster_to_tensor(walls_path)
     dirwalls, dataset5 = load_raster_to_tensor(aspect_path)
           
@@ -411,12 +418,13 @@ def compute_utci(building_dsm_path, tree_path, dem_path, walls_path, aspect_path
     print(f"[INFO] Timezone: {timezone_name}, UTC offset: {utc} hours")
     YYYY, altitude, azimuth, zen, jday, leafon, dectime, altmax = Solweig_2015a_metdata_noload(met_file, location, utc)
     temp1[temp1 < 0.] = 0.
+    trunk_height = trunk if trunk is not None else temp1 * 0.25
     vegdem = temp1 + temp2
-    vegdem2 = torch.add(temp1 * 0.25, temp2)
+    vegdem2 = trunk_height + temp2
     bush = torch.logical_not(vegdem2 * vegdem) * vegdem
     vegdsm = temp1 + a
     vegdsm[vegdsm == a] = 0
-    vegdsm2 = temp1 * 0.25 + a
+    vegdsm2 = trunk_height + a
     vegdsm2[vegdsm2 == a] = 0
     # fveg = (temp1 > 0).float()
     amaxvalue = torch.maximum(a.max(), vegdem.max())

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -8,6 +8,7 @@ tiling, and meteorological data extraction.
 import unittest
 import numpy as np
 import os
+import shutil
 import tempfile
 from osgeo import gdal, osr
 import datetime
@@ -126,6 +127,85 @@ class TestDatetimeExtraction(unittest.TestCase):
         
         with self.assertRaises(ValueError):
             extract_datetime_strict('invalid_filename.nc')
+
+
+class TestPreprocessorTrunkZone(unittest.TestCase):
+    """Test that ppr tiles an optional trunk-zone DSM raster."""
+
+    def setUp(self):
+        self.base_path = tempfile.mkdtemp()
+        for name in ('Building_DSM.tif', 'DEM.tif', 'Trees.tif', 'TrunkZone.tif'):
+            self._create_raster(os.path.join(self.base_path, name))
+
+        self.metfile = os.path.join(self.base_path, 'met.txt')
+        with open(self.metfile, 'w') as f:
+            f.write('iy id it imin Q* QH QE Qs Qf Wind RH Td press rain Kdn snow ldown fcld wuh xsmd lai_hr Kdiff Kdir Wd\n')
+            for h in range(24):
+                f.write(f"2020 200 {h} 0 -999 -999 -999 -999 -999 1.0 50 20 100 0 0 -999 -999 -999 -999 -999 -999 -999 -999 -999\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.base_path, ignore_errors=True)
+
+    def _create_raster(self, path, width=50, height=50, pixel_size=1.0):
+        driver = gdal.GetDriverByName('GTiff')
+        ds = driver.Create(path, width, height, 1, gdal.GDT_Float32)
+        ds.SetGeoTransform((0, pixel_size, 0, 0, 0, -pixel_size))
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32614)
+        ds.SetProjection(srs.ExportToWkt())
+        ds.GetRasterBand(1).WriteArray(np.ones((height, width), dtype=np.float32) * 10)
+        ds.FlushCache()
+        ds = None
+        return path
+
+    def test_trunkzone_tiles_created(self):
+        """A provided trunk-zone DSM should be validated and tiled alongside the DSM."""
+        from solweig_gpu.preprocessor import ppr
+
+        preprocess_dir = os.path.join(self.base_path, 'processed_inputs')
+        ppr(
+            base_path=self.base_path,
+            building_dsm_filename='Building_DSM.tif',
+            dem_filename='DEM.tif',
+            trees_filename='Trees.tif',
+            landcover_filename=None,
+            windcoeff_filename=None,
+            tile_size=3600,
+            overlap=20,
+            selected_date_str='2020-07-18',
+            use_own_met=True,
+            own_met_file=self.metfile,
+            preprocess_dir=preprocess_dir,
+            trunkzone_filename='TrunkZone.tif',
+        )
+
+        trunkzone_dir = os.path.join(preprocess_dir, 'TrunkZone')
+        self.assertTrue(os.path.isdir(trunkzone_dir))
+        tiles = [f for f in os.listdir(trunkzone_dir) if f.endswith('.tif')]
+        self.assertTrue(len(tiles) >= 1)
+
+    def test_no_trunkzone_dir_when_not_provided(self):
+        """Without a trunk-zone DSM, no TrunkZone tiles should be created."""
+        from solweig_gpu.preprocessor import ppr
+
+        preprocess_dir = os.path.join(self.base_path, 'processed_inputs')
+        ppr(
+            base_path=self.base_path,
+            building_dsm_filename='Building_DSM.tif',
+            dem_filename='DEM.tif',
+            trees_filename='Trees.tif',
+            landcover_filename=None,
+            windcoeff_filename=None,
+            tile_size=3600,
+            overlap=20,
+            selected_date_str='2020-07-18',
+            use_own_met=True,
+            own_met_file=self.metfile,
+            preprocess_dir=preprocess_dir,
+            trunkzone_filename=None,
+        )
+
+        self.assertFalse(os.path.isdir(os.path.join(preprocess_dir, 'TrunkZone')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allow to provide a trunk zone DSM just as with UMEP/Solweig instead of the default ration of 25% trunk height.

Core changes in `solweig_gpu/utci_process.py`, the rest is only wiring variable